### PR TITLE
Integrate Make webhook

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # Idea Submission Form
 
-This project provides a small Node.js application with a form to collect ideas for different bots. The form asks for first name, last name, email address, the target bot, and a detailed description of the idea.
+This project provides a small Node.js application with a form to collect ideas for different bots. The form asks for first name, last name, email address, the target bot, and a detailed description of the idea. The server only serves the form page; submissions are sent to a Make webhook.
 
-Submitted ideas are sent to **ki-test@gmx.com** via email. SMTP settings must be supplied via environment variables.
+Submitted ideas are posted directly to a Make webhook and can then be processed there.
+If you want to use the previous email functionality, supply SMTP credentials via
+environment variables and change the form action back to `/submit`.
 
 ## Setup
 

--- a/index.html
+++ b/index.html
@@ -6,7 +6,8 @@
 </head>
 <body>
   <h1>Idee für Bot einreichen</h1>
-  <form action="/submit" method="post">
+  <!-- Daten werden direkt an den Make-Webhook gesendet -->
+  <form action="https://hook.us2.make.com/gdk7iqfavitf7qqplb3cyiptk7bf3l4x" method="post">
     <label for="vorname">Vorname:</label><br>
     <input type="text" id="vorname" name="vorname" required><br>
 


### PR DESCRIPTION
## Summary
- send form submissions directly to the Make webhook
- clarify README instructions about Make integration

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685714c18fc48324ada576b0087e1b00