### PR TITLE
Fix form submission and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # Idea Submission Form
 
-This project provides a small Node.js application with a form to collect ideas for different bots. The form asks for first name, last name, email address, the target bot, and a detailed description of the idea.
+This project provides a small Node.js application with a form to collect ideas for different bots. The form uses a ServiceNow-like layout and gathers the user's first name, last name, email address, the target bot and a detailed description.
 
-Submitted ideas are sent to **ki-test@gmx.com** via email. SMTP settings must be supplied via environment variables.
+Submitted ideas are sent via JavaScript `fetch` to the Make webhook (`https://hook.us2.make.com/gdk7iqfavitf7qqplb3cyiptk7bf3l4x`).
+Because the form submits directly to Make, `index.html` can be hosted as a static page without running the Node server.
+If you want to revert to the original email submission, provide SMTP credentials via environment variables and change the form logic to post to `/submit`.
 
 ## Setup
 
@@ -20,7 +22,7 @@ Submitted ideas are sent to **ki-test@gmx.com** via email. SMTP settings must be
 
 3. Start the application:
    ```bash
-   node server.js
+   npm start
    ```
 
 4. Open `http://localhost:3000` in your browser and fill out the form.

--- a/index.html
+++ b/index.html
@@ -3,10 +3,55 @@
 <head>
 <meta charset="UTF-8">
 <title>Idee einreichen</title>
+<style>
+body {
+  font-family: Arial, sans-serif;
+  background-color: #f5f5f5;
+  margin: 0;
+  padding: 20px;
+}
+.container {
+  width: 500px;
+  margin: 40px auto;
+  background: #fff;
+  padding: 20px;
+  border-radius: 4px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+label {
+  display: block;
+  margin-top: 10px;
+  font-weight: bold;
+}
+input,
+select,
+textarea {
+  width: 100%;
+  padding: 8px;
+  box-sizing: border-box;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  margin-top: 4px;
+}
+button {
+  margin-top: 15px;
+  padding: 10px;
+  background-color: #0072C6;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+button:hover {
+  background-color: #005a9e;
+}
+</style>
 </head>
 <body>
-  <h1>Idee für Bot einreichen</h1>
-  <form action="/submit" method="post">
+  <div class="container">
+    <h1>Idee für Bot einreichen</h1>
+    <!-- Daten werden via JavaScript an den Make-Webhook gesendet -->
+    <form id="ideaForm">
     <label for="vorname">Vorname:</label><br>
     <input type="text" id="vorname" name="vorname" required><br>
 
@@ -29,5 +74,34 @@
 
     <button type="submit">Senden</button>
   </form>
+  </div>
+  <script>
+    document.getElementById('ideaForm').addEventListener('submit', async function (e) {
+      e.preventDefault();
+      const form = e.target;
+      const data = {
+        vorname: form.vorname.value,
+        name: form.name.value,
+        email: form.email.value,
+        bot: form.bot.value,
+        idea: form.idea.value
+      };
+      try {
+        const res = await fetch('https://hook.us2.make.com/gdk7iqfavitf7qqplb3cyiptk7bf3l4x', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(data)
+        });
+        if (res.ok) {
+          alert('Vielen Dank für Ihre Idee!');
+          this.reset();
+        } else {
+          alert('Fehler beim Senden der Daten.');
+        }
+      } catch (err) {
+        alert('Fehler beim Senden der Daten.');
+      }
+    });
+  </script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -2,8 +2,9 @@
   "name": "kibot",
   "version": "1.0.0",
   "description": "",
-  "main": "index.js",
+  "main": "server.js",
   "scripts": {
+    "start": "node server.js",
     "test": "echo \"No tests\""
   },
   "keywords": [],


### PR DESCRIPTION
## Summary
- refine JavaScript form handler to read fields reliably
- add `npm start` script in package.json
- document running the server with `npm start` and note that index.html can be hosted statically

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685714c18fc48324ada576b0087e1b00