### PR TITLE
Update webhook proxy success handling

### DIFF
--- a/netlify/functions/webhook-proxy.js
+++ b/netlify/functions/webhook-proxy.js
@@ -22,13 +22,15 @@ exports.handler = async (event, context) => {
       body:    event.body,
     });
     console.log(`→ upstream status: ${resp.status} ${resp.statusText}`);
-    const text = await resp.text();
-    console.log('→ upstream body:', text);
 
     if (!resp.ok) {
+      const text = await resp.text();
+      console.error('→ upstream body:', text);
       return { statusCode: resp.status, body: `Forward error: ${resp.statusText}` };
     }
-    return { statusCode: 200, body: 'OK' };
+
+    const text = await resp.text();
+    return { statusCode: resp.status, body: text };
   } catch (err) {
     console.error('❌ fetch threw:', err);
     return { statusCode: 500, body: `Internal error: ${err}` };


### PR DESCRIPTION
## Summary
- return upstream response text instead of a fixed `OK`
- log unexpected bodies when upstream fails

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6859379bcd448324a0768b4c386a19e5