### PR TITLE
Add node-fetch and configure Node 18

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -5,3 +5,6 @@
 [functions]
   # falls du Functions nutzt, lass hier nur das Verzeichnis stehen
   directory = "netlify/functions"
+
+[build.environment]
+  NODE_VERSION = "18"

--- a/netlify/functions/webhook-proxy.js
+++ b/netlify/functions/webhook-proxy.js
@@ -1,4 +1,5 @@
 // netlify/functions/webhook-proxy.js
+const fetch = require('node-fetch');
 exports.handler = async (event, context) => {
   console.log('–– EVENT BODY ––');
   console.log(event.body);

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "build": "echo 'Static site – kein Build notwendig'"
   },
   "dependencies": {
-    "puppeteer": "^22.8.2"
+    "puppeteer": "^22.8.2",
+    "node-fetch": "^2.6.7"
   }
 }


### PR DESCRIPTION
## Summary
- add `node-fetch` to dependencies
- import it at the top of the Netlify function
- specify Node 18 runtime in `netlify.toml`

## Testing
- `node validate-toml.js` *(fails: Cannot find module 'toml')*

------
https://chatgpt.com/codex/tasks/task_e_685937a80a708324afb59d923252f504