### PR TITLE
Fix Netlify timeout

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -6,5 +6,10 @@
   # falls du Functions nutzt, lass hier nur das Verzeichnis stehen
   directory = "netlify/functions"
 
+[functions."webhook-proxy"]
+  # Erhöht das Timeout auf das Netlify-Maximum, damit
+  # längere Make-Szenarien nicht abbrechen
+  timeout = 26
+
 [build.environment]
   NODE_VERSION = "18"


### PR DESCRIPTION
## Summary
- extend Netlify function timeout for `webhook-proxy`

## Testing
- `node validate-toml.js` *(fails: Cannot find module 'toml')*

------
https://chatgpt.com/codex/tasks/task_e_68593f8c37a883248da3b1902ebd2071