### PR TITLE
Update manifest start_url to use index.html

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "KI Assistant Chatbot",
   "short_name": "KIChatbot",
-  "start_url": "./assistant-ki-app-test.html",
+  "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#f8fafc",
   "theme_color": "#2346e4",


### PR DESCRIPTION
## Summary
- update `start_url` in manifest to `./index.html`

## Testing
- `npm run build` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685944df55ac832491e131c6dcece1eb